### PR TITLE
Modify the merkletree gadget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ Cargo.lock
 .cargo/config
 .DS_Store
 .vscode/
-~/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ Cargo.lock
 /cli/trusted_setup
 .cargo/config
 .DS_Store
+.vscode/
+~/

--- a/src/gadgets/abstract_hash.rs
+++ b/src/gadgets/abstract_hash.rs
@@ -3,12 +3,14 @@ use scheme::r1cs::{ConstraintSystem, SynthesisError, Variable};
 
 use crate::Vec;
 
-pub trait AbstractHashOutput: Clone {
+pub trait AbstractHashOutput<F: PrimeField>: Clone {
     fn get_variables(&self) -> Vec<Variable>;
+
+    fn get_variable_values(&self) -> Vec<Option<F>>;
 }
 
 pub trait AbstractHash<F: PrimeField> {
-    type Output: AbstractHashOutput;
+    type Output: AbstractHashOutput<F>;
 
     fn hash_enforce<CS>(cs: CS, params: &[&Self::Output]) -> Result<Self::Output, SynthesisError>
     where

--- a/src/gadgets/mimc.rs
+++ b/src/gadgets/mimc.rs
@@ -169,9 +169,13 @@ impl<F: PrimeField> AbstractHashMimcOutput<F> {
     }
 }
 
-impl<F: PrimeField> AbstractHashOutput for AbstractHashMimcOutput<F> {
+impl<F: PrimeField> AbstractHashOutput<F> for AbstractHashMimcOutput<F> {
     fn get_variables(&self) -> Vec<Variable> {
         vec![self.variable]
+    }
+
+    fn get_variable_values(&self) -> Vec<Option<F>> {
+        vec![self.value]
     }
 }
 

--- a/src/gadgets/poseidon.rs
+++ b/src/gadgets/poseidon.rs
@@ -800,9 +800,13 @@ impl<F: PrimeField> AbstractHashPoseidonOutput<F> {
     }
 }
 
-impl<F: PrimeField> AbstractHashOutput for AbstractHashPoseidonOutput<F> {
+impl<F: PrimeField> AbstractHashOutput<F> for AbstractHashPoseidonOutput<F> {
     fn get_variables(&self) -> Vec<Variable> {
         vec![self.variable]
+    }
+
+    fn get_variable_values(&self) -> Vec<Option<F>> {
+        vec![self.value]
     }
 }
 

--- a/src/gadgets/rescue.rs
+++ b/src/gadgets/rescue.rs
@@ -569,9 +569,13 @@ impl<F: PrimeField> AbstractHashRescueOutput<F> {
     }
 }
 
-impl<F: PrimeField> AbstractHashOutput for AbstractHashRescueOutput<F> {
+impl<F: PrimeField> AbstractHashOutput<F> for AbstractHashRescueOutput<F> {
     fn get_variables(&self) -> Vec<Variable> {
         vec![self.variable]
+    }
+
+    fn get_variable_values(&self) -> Vec<Option<F>> {
+        vec![self.value]
     }
 }
 

--- a/src/gadgets/sha256.rs
+++ b/src/gadgets/sha256.rs
@@ -275,7 +275,6 @@ impl AbstractHashSha256Output {
             variables.push(alloc.get_variable());
             values.push(alloc.into());
         }
-
         Ok(Self {
             value: Some(values),
             variables: variables,
@@ -287,9 +286,22 @@ impl AbstractHashSha256Output {
     }
 }
 
-impl AbstractHashOutput for AbstractHashSha256Output {
+impl<F: PrimeField> AbstractHashOutput<F> for AbstractHashSha256Output {
     fn get_variables(&self) -> Vec<Variable> {
         self.variables.clone()
+    }
+
+    fn get_variable_values(&self) -> Vec<Option<F>> {
+        let value_vec = self.value.clone().unwrap();
+        let mut ret_vec = vec![Some(F::zero()); value_vec.len() as usize];
+        for i in 0..value_vec.len() as usize {
+            ret_vec[i] = if value_vec[i].get_value().unwrap() {
+                Some(F::one())
+            } else {
+                Some(F::zero())
+            }
+        }
+        ret_vec
     }
 }
 


### PR DESCRIPTION
Modify the merkletree gadget and add constraints on the left and right node selection for the merkletree gadget. sha256 already contains the 01-bit constraint of the hash value, mimc, poseidon, and rescue hashes do not require boolean constraints.