### PR TITLE
plonk: rename null_var as zero_var

### DIFF
--- a/plonk/src/composer/arithmetic.rs
+++ b/plonk/src/composer/arithmetic.rs
@@ -17,7 +17,7 @@ impl<F: Field> Composer<F> {
 
         let aux = match aux {
             Some(aux) => aux,
-            None => (self.null_var, F::zero()),
+            None => (self.zero_var, F::zero()),
         };
 
         self.permutation.insert_gate(aux.0, l.0, r.0, o.0, index);
@@ -57,7 +57,7 @@ impl<F: Field> Composer<F> {
         self.create_poly_gate(
             (l, F::one()),
             (r, -F::one()),
-            (self.null_var, F::zero()),
+            (self.zero_var, F::zero()),
             None,
             F::zero(),
             F::zero(),

--- a/plonk/src/composer/mod.rs
+++ b/plonk/src/composer/mod.rs
@@ -34,7 +34,7 @@ pub struct Composer<F: Field> {
     w_2: Vec<Variable>,
     w_3: Vec<Variable>,
 
-    null_var: Variable,
+    zero_var: Variable,
     permutation: Permutation<F>,
     assignment: Map<Variable, F>,
 }
@@ -59,11 +59,11 @@ impl<F: Field> Composer<F> {
             w_2: Vec::new(),
             w_3: Vec::new(),
 
-            null_var: Variable(0),
+            zero_var: Variable(0),
             permutation: Permutation::new(),
             assignment: Map::new(),
         };
-        cs.null_var = cs.alloc_and_assign(F::zero());
+        cs.zero_var = cs.alloc_and_assign(F::zero());
 
         cs
     }


### PR DESCRIPTION
I find `null_var` is somewhat misleading, given it always has a concrete value of `0`.