### PR TITLE
include more public values for secure FS transform

### DIFF
--- a/bulletproofs/src/arithmetic_circuit.rs
+++ b/bulletproofs/src/arithmetic_circuit.rs
@@ -296,13 +296,15 @@ where
         n_w,
     };
 
-    let proof = prove(&generators, &r1cs_circuit, &input, rng);
+    let mut prover = Transcript::new(b"protocol3");
+    let proof = prove(&mut prover, &generators, &r1cs_circuit, &input, rng);
 
     Ok((generators, r1cs_circuit.matrix_to_map(), proof))
 }
 
 // bulletproofs arithmetic circuit proof with R1CS format
 pub fn prove<G, R>(
+    transcript: &mut Transcript,
     gens: &Generators<G>,
     r1cs_circuit: &R1csCircuit<G>,
     input: &Assignment<G>,
@@ -312,8 +314,6 @@ where
     G: Curve,
     R: Rng,
 {
-    let mut transcript = Transcript::new(b"protocol3");
-
     let n = input.aL.len();
     assert_eq!(n, input.aR.len());
     assert_eq!(n, input.aO.len());
@@ -334,8 +334,24 @@ where
     // choose blinding vectors sL, sR
     let n_max = cmp::max(n, n_w);
     let N = n_max.next_power_of_two(); // N must be greater than or equal to n & n_w
+
     transcript.append_u64(b"n", n as u64);
     transcript.append_u64(b"N", N as u64);
+    transcript.append_u64(b"k", gens.k as u64);
+    transcript.append_u64(b"n_w", gens.n_w as u64);
+
+    transcript.append_message(b"g", &to_bytes!(gens.g).unwrap());
+    transcript.append_message(b"h", &to_bytes!(gens.h).unwrap());
+    transcript.append_message(b"u", &to_bytes!(gens.u).unwrap());
+    transcript.append_message(b"g_vec_N", &to_bytes!(gens.g_vec_N).unwrap());
+    transcript.append_message(b"h_vec_N", &to_bytes!(gens.h_vec_N).unwrap());
+
+    transcript.append_message(b"cL", &to_bytes!(r1cs_circuit.CL).unwrap());
+    transcript.append_message(b"cR", &to_bytes!(r1cs_circuit.CR).unwrap());
+    transcript.append_message(b"cO", &to_bytes!(r1cs_circuit.CO).unwrap());
+
+    transcript.append_message(b"s", &to_bytes!(input.s).unwrap());
+
     let mut sL: Vec<G::Fr> = (0..n_max).map(|_| G::Fr::rand(rng)).collect();
     let mut sR: Vec<G::Fr> = (0..n_max).map(|_| G::Fr::rand(rng)).collect();
 
@@ -537,6 +553,8 @@ where
     transcript.append_message(b"t_x", &to_bytes!(t_x).unwrap());
     transcript.append_message(b"tau_x", &to_bytes!(tau_x).unwrap());
     transcript.append_message(b"mu", &to_bytes!(mu).unwrap());
+    transcript.append_message(b"l_x", &to_bytes!(l_x).unwrap());
+    transcript.append_message(b"r_x", &to_bytes!(r_x).unwrap());
 
     let mut buf_x_1 = [0u8; 31];
     transcript.challenge_bytes(b"x_1", &mut buf_x_1); // notice: challenge x in protocol1 to avoid cheating from prover
@@ -549,9 +567,11 @@ where
         .into_affine();
 
     let IPP = inner_product_proof::prove(
+        transcript,
         gens.g_vec_N.clone(),
         gens.h_vec_N.clone(),
         ux,
+        &IPP_P.into_projective(),
         l_x.clone(),
         r_x.clone(),
     );
@@ -593,14 +613,16 @@ where
 }
 
 pub fn verify_proof<G: Curve>(
+    transcript: &mut Transcript,
     gens: &Generators<G>,
     proof: &Proof<G>,
     r1cs_circuit: &R1csCircuit<G>,
     public_inputs: &[G::Fr],
 ) -> Result<bool, SynthesisError> {
-    let mut transcript = Transcript::new(b"protocol3");
     let zero = G::Fr::zero();
     let one = G::Fr::one();
+    let mut r1_public_inputs = vec![one];
+    r1_public_inputs.extend(public_inputs);
 
     // generators
     let g_vec: Vec<G::Affine> = gens.g_vec_N.clone();
@@ -610,6 +632,20 @@ pub fn verify_proof<G: Curve>(
 
     transcript.append_u64(b"n", gens.n as u64);
     transcript.append_u64(b"N", gens.N as u64);
+    transcript.append_u64(b"k", gens.k as u64);
+    transcript.append_u64(b"n_w", gens.n_w as u64);
+
+    transcript.append_message(b"g", &to_bytes!(gens.g).unwrap());
+    transcript.append_message(b"h", &to_bytes!(gens.h).unwrap());
+    transcript.append_message(b"u", &to_bytes!(gens.u).unwrap());
+    transcript.append_message(b"g_vec_N", &to_bytes!(gens.g_vec_N).unwrap());
+    transcript.append_message(b"h_vec_N", &to_bytes!(gens.h_vec_N).unwrap());
+
+    transcript.append_message(b"cL", &to_bytes!(r1cs_circuit.CL).unwrap());
+    transcript.append_message(b"cR", &to_bytes!(r1cs_circuit.CR).unwrap());
+    transcript.append_message(b"cO", &to_bytes!(r1cs_circuit.CO).unwrap());
+
+    transcript.append_message(b"s", &to_bytes!(r1_public_inputs).unwrap());
 
     transcript.append_message(b"A_I", &to_bytes!(proof.A_I).unwrap());
     transcript.append_message(b"A_O", &to_bytes!(proof.A_O).unwrap());
@@ -713,8 +749,7 @@ pub fn verify_proof<G: Curve>(
             }
         }
     }
-    let mut r1_public_inputs = vec![G::Fr::one()];
-    r1_public_inputs.extend(public_inputs);
+
     let c = vector_matrix_product_t::<G::Fr>(&r1_public_inputs, &C1);
 
     // zQ * WL, zQ * WR
@@ -754,6 +789,9 @@ pub fn verify_proof<G: Curve>(
     transcript.append_message(b"t_x", &to_bytes!(proof.t_x).unwrap());
     transcript.append_message(b"tau_x", &to_bytes!(proof.tau_x).unwrap());
     transcript.append_message(b"mu", &to_bytes!(proof.mu).unwrap());
+    transcript.append_message(b"l_x", &to_bytes!(proof.l_x).unwrap());
+    transcript.append_message(b"r_x", &to_bytes!(proof.r_x).unwrap());
+
     let mut buf_x_1 = [0u8; 31];
     transcript.challenge_bytes(b"x_1", &mut buf_x_1); // notice: challenge x in protocol1 to avoid cheating from prover
     let x_1 = random_bytes_to_fr::<G::Fr>(&buf_x_1);
@@ -763,6 +801,7 @@ pub fn verify_proof<G: Curve>(
     // USE IPP here
     // assert_eq!(proof.t_x, inner_product::<G::Fr>(&proof.l_x, &proof.r_x));
     if !inner_product_proof::verify(
+        transcript,
         gens.g_vec_N.clone(),
         gens.h_vec_N.clone(),
         ux,
@@ -884,8 +923,10 @@ mod tests {
             n_w,
         };
 
-        let proof = prove(&generators, &r1cs_circuit, &input, rng);
-        assert!(verify_proof(&generators, &proof, &r1cs_circuit, &statement).unwrap());
+        let mut prover = Transcript::new(b"protocol3");
+        let proof = prove(&mut prover, &generators, &r1cs_circuit, &input, rng);
+        let mut verifier = Transcript::new(b"protocol3");
+        assert!(verify_proof(&mut verifier, &generators, &proof, &r1cs_circuit, &statement).unwrap());
     }
 
     // #[test]

--- a/bulletproofs/tests/mini.rs
+++ b/bulletproofs/tests/mini.rs
@@ -7,6 +7,7 @@ use zkp_r1cs::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
 use ark_bls12_381::{Bls12_381 as E, Fr};
 use ark_serialize::*;
 use std::time::Instant;
+use merlin::Transcript;
 
 struct Mini<F: PrimeField> {
     pub x: Option<F>,
@@ -72,10 +73,12 @@ fn mini_bulletproofs() {
     };
 
     let v_start = Instant::now();
-    assert!(verify_proof(&gens, &proof, &r1cs, &[Fr::from(10u32)]).unwrap());
+    let mut verifier = Transcript::new(b"protocol3");
+    assert!(verify_proof(&mut verifier, &gens, &proof, &r1cs, &[Fr::from(10u32)]).unwrap());
     let v_time = v_start.elapsed();
     println!("[Bulletproofs] Verify time  : {:?}", v_time);
 
+    let mut verifier = Transcript::new(b"protocol3");
     let proof2 = Proof::<E>::deserialize(&proof_bytes[..]).unwrap();
-    assert!(verify_proof(&gens, &proof2, &r1cs, &[Fr::from(10u32)]).unwrap());
+    assert!(verify_proof(&mut verifier, &gens, &proof2, &r1cs, &[Fr::from(10u32)]).unwrap());
 }

--- a/bulletproofs/tests/mini.rs
+++ b/bulletproofs/tests/mini.rs
@@ -7,7 +7,6 @@ use zkp_r1cs::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
 use ark_bls12_381::{Bls12_381 as E, Fr};
 use ark_serialize::*;
 use std::time::Instant;
-use merlin::Transcript;
 
 struct Mini<F: PrimeField> {
     pub x: Option<F>,
@@ -73,12 +72,10 @@ fn mini_bulletproofs() {
     };
 
     let v_start = Instant::now();
-    let mut verifier = Transcript::new(b"protocol3");
-    assert!(verify_proof(&mut verifier, &gens, &proof, &r1cs, &[Fr::from(10u32)]).unwrap());
+    assert!(verify_proof(&gens, &proof, &r1cs, &[Fr::from(10u32)]).unwrap());
     let v_time = v_start.elapsed();
     println!("[Bulletproofs] Verify time  : {:?}", v_time);
 
-    let mut verifier = Transcript::new(b"protocol3");
     let proof2 = Proof::<E>::deserialize(&proof_bytes[..]).unwrap();
-    assert!(verify_proof(&mut verifier, &gens, &proof2, &r1cs, &[Fr::from(10u32)]).unwrap());
+    assert!(verify_proof(&gens, &proof2, &r1cs, &[Fr::from(10u32)]).unwrap());
 }


### PR DESCRIPTION
Trail of Bits found that insecure implementations of the Fiat-Shamir transformation in bulletproofs could allow malicious users to forge proofs for random statements.
- https://blog.trailofbits.com/2022/04/13/part-1-coordinated-disclosure-of-vulnerabilities-affecting-girault-bulletproofs-and-plonk/
- https://blog.trailofbits.com/2022/04/15/the-frozen-heart-vulnerability-in-bulletproofs/

The [bulletproofs paper](https://eprint.iacr.org/2017/1066.pdf) has also been updated to emphasize the description of secure Fiat-Shamir transformation for the protocol.

<img width="647" alt="image" src="https://user-images.githubusercontent.com/36690236/163777650-13652206-3a56-4a5c-871d-0dcf9bf85d73.png">

Our implementation does not include the range proofs section of bulletproofs as discussed in Trail of Bits's posts. In fact, our implementation of bulletproofs is a variant of the original version with direct support of R1CS. But we did miss some public values from the statement.

In this pull request, we add public assignment (`s`), the circuit description (`cL`, `cR`, `cO`), and generators (`g`, `h`) to the transcript of circuit proof and add `n`, `u`, `P`, and generators (`g`, `h`) to the transcript of inner product proof.